### PR TITLE
Fixed the link for Server Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ pulling in the updates for the sub-module.
 ### Server Documentation
 
 Docs for CircleCI Server Administration are built in a slightly different way;
-please refer to the [server build documentation](./docs/server-docs.md)
-
+please refer to the [server build documentation](./docs/server-docs.adoc)
 ## License Information
 Documentation (guides, references, and associated images) is licensed as
 Creative Commons Attribution-NonCommercial-ShareAlike CC BY-NC-SA. The full


### PR DESCRIPTION
# Description 
I have fixed the link for Server Build Documentation. 

# Reasons
The link was leading to a 404 error page and needed a fix. 